### PR TITLE
Properly parse bower.json

### DIFF
--- a/test/download.js
+++ b/test/download.js
@@ -46,4 +46,19 @@ describe('download', function(){
       });
     });
   });
+
+  it('Returns a package with dependencies', function(done){
+    var expected = {
+      'jquery': 'bower:jquery@master'
+    };
+    bower.download('bootstrap', '3.0.3', '3.0.3', dir, function(pkg){
+      var deps = pkg.map;
+
+      assert.equal(pkg.main, './dist/js/bootstrap.js');
+      assert.notEqual(deps, undefined);
+      assert.equal(Object.keys(deps).length, 1);
+      assert.deepEqual(deps, expected);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Some work is needed to parse the `bower.json` into a format acceptable by jspm so that all dependencies are retrieved. [Example bower.json](https://github.com/twbs/bootstrap/blob/master/bower.json). Open questions:
1. What can we do about packages with multiple `main`s?
2. Is it ok to use the same semver logic as the npm endpoint?
   
   cc @guybedford
